### PR TITLE
Display 'try searching for' only for core

### DIFF
--- a/frontend/Component/Package.elm
+++ b/frontend/Component/Package.elm
@@ -24,7 +24,7 @@ view versionChan searchChan w pkg searchTerm maybeReadme =
     , flow right
       [ spacer 30 5
       , ModuleList.view (w - 30 - 200 - 30) searchTerm pkg
-      , Search.view searchChan 200 searchTerm
+      , Search.view searchChan 200 pkg searchTerm
       ]
     , spacer w 12
     , color C.lightGrey (spacer w 1)

--- a/frontend/Component/Package/Search.elm
+++ b/frontend/Component/Package/Search.elm
@@ -30,10 +30,13 @@ description pkg = Markdown.toHtml <| """
 <span style="font-size: 12px; color: rgb(216, 221, 225);">
 Search through all the functions and operators in this package.
 """
-    ++ if isCore pkg then " Try searching for `|>` or `map`." else "" ++ "</span>"
+    ++ (if isCore pkg then " Try searching for `|>` or `map`." else "") ++ "</span>"
+
 
 isCore : ModuleList.Model -> Bool
-isCore pkg = pkg.user == "elm-lang" && pkg.name == "core"
+isCore pkg =
+    pkg.user == "elm-lang" && pkg.name == "core"
+
 
 inputStyle =
   style

--- a/frontend/Component/Package/Search.elm
+++ b/frontend/Component/Package/Search.elm
@@ -7,9 +7,10 @@ import Html.Events (..)
 import LocalChannel as LC
 import Markdown
 
+import Component.Package.ModuleList as ModuleList
 
-view : LC.LocalChannel String -> Int -> String -> Element
-view fieldChan width fieldContent =
+view : LC.LocalChannel String -> Int -> ModuleList.Model -> String -> Element
+view fieldChan width pkg fieldContent =
   toElement width 150 <|
   div []
     [ input
@@ -19,20 +20,20 @@ view fieldChan width fieldContent =
         , inputStyle
         ]
         []
-    , description
+    , description pkg
     ]
 
 
-description : Html
-description = Markdown.toHtml """
+description : ModuleList.Model -> Html
+description pkg = Markdown.toHtml <| """
 
 <span style="font-size: 12px; color: rgb(216, 221, 225);">
 Search through all the functions and operators in this package.
-Try searching for `|>` or `map`.
-</span>
-
 """
+    ++ if isCore pkg then " Try searching for `|>` or `map`." else "" ++ "</span>"
 
+isCore : ModuleList.Model -> Bool
+isCore pkg = pkg.user == "elm-lang" && pkg.name == "core"
 
 inputStyle =
   style


### PR DESCRIPTION
As discussed at #11, fixes an issue where the user is encouraged to search for functions that do not exist in 3rd party libraries. We pipe the model into the search view and handle it from there.

I was unable to get the backend server running (a Haskell dependency was missing a DLL or some BS), but I was able to compile the elm front end. I added but did not commit `"exposed-modules": ["Component.Package"],` to `package.json` to do this, so yes it really compiled, I got errors and fixed them. So: this is definitely valid Elm, but I haven't tested in a web browser to make sure (1) the if-statement triggers correctly for core and non-core libraries (2) the HTML looks good (no big spaces or anything).

I know Evan is busy, so I would appreciate if members of the Elm community could verify this is a browser.