### PR TITLE
modest rewording proposal

### DIFF
--- a/frontend/Component/Header.elm
+++ b/frontend/Component/Header.elm
@@ -37,7 +37,7 @@ view versionChan innerWidth user package version versions maybeModule =
       "https://github.com/" ++ user ++ "/" ++ package ++ "/tree/" ++ version
 
     viewSource =
-      Text.fromString "View Source"
+      Text.fromString "Browse Source"
         |> Text.link githubLink
         |> Text.height 12
         |> centered


### PR DESCRIPTION
Related to #35. As [argued here](https://groups.google.com/d/msg/elm-discuss/5dwJjy-kd5g/d1dxi4yxv4IJ), the link text "View Source" raises wrong expectations. I think "Browse Source" solves this, since it already suggests that one may still need to navigate some directory structure after having landed on the GitHub page of the repo. :-)

@raould, is this better?