### PR TITLE
Improve the docs format and design guidelines pages.

### DIFF
--- a/frontend/Page/DesignGuidelines.elm
+++ b/frontend/Page/DesignGuidelines.elm
@@ -96,7 +96,7 @@ a library, so give them some structure!
 
 Function composition works better when the data structure is the last argument:
 
-```haskell
+```elm
 getCombinedHeight people =
     people
       |> map .height
@@ -106,7 +106,7 @@ getCombinedHeight people =
 Folding also works better when the data structure is the last argument of the
 accumulator function. `foldl`, `foldr`, and `foldp` all work this way:
 
-```haskell
+```elm
 -- Good API
 remove : String -> Dict String a -> Dict String a
 

--- a/frontend/Page/DocumentationFormat.elm
+++ b/frontend/Page/DocumentationFormat.elm
@@ -52,7 +52,7 @@ Here is an example from [the `String` library](/packages/elm-lang/core/latest/St
 want to create a string primarly by consing, perhaps for decoding
 something.
 
-    fromList ['a','b','c'] == "abc"
+    fromList ['e','l','m'] == "elm"
 -}
 fromList : List Char -> String
 fromList = ...
@@ -63,22 +63,23 @@ Notice that:
   * A documentation comment starts `{-|` and ends with `-}`. The vertical
     bar indicates that it is a special comment.
   * The text begins after a single space, and all subsequent lines are
-    aligned with the zeroth column.
-  * Code is indented four spaces.
+    aligned all the way to the left.
   * There is an example that shows a typical use of the function.
+  * This example is indented four spaces.
+  * The comment is closed on its own line.
   * There is an explicit type annotation.
 
-All of these things are necessary. Use this style when documenting your
-publicly exposed functions. The goal is to have consistency across all
-codebases, so readers can glance through easily and writers do not need
-to argue about style.
+For publicly exposed functions, type annotations and comments are
+required, and examples are best practice. The goal is to have
+consistency across all codebases, so readers can glance through easily
+and writers do not need to argue about style.
 
 ## Documenting a module
 
 Here is the module documentation for [the `Maybe` library](/packages/elm-lang/core/latest/Maybe):
 
 ```haskell
-module Maybe (Maybe(..), maybe, isJust, isNothing, map) where
+module Maybe (Maybe(Just,Nothing), andThen, map, withDefault, oneOf) where
 
 {-| This library fills a bunch of important niches in Elm. A `Maybe` can help
 you with optional arguments, error handling, and records with optional fields.
@@ -98,22 +99,31 @@ you with optional arguments, error handling, and records with optional fields.
 This represents the text that actually gets displayed as [the
 documentation](/packages/elm-lang/core/latest/Maybe) for a module. Notice that:
 
+  * The module lists what values are exported. Maybes are not an
+    opaque type, as the tags are exported as well.
   * The module documentation comes after the module declaration, but
     before the imports. This is so the first thing in the file is the
     module name and the second is how to use it.
-  * The first line starts after a single space, and all subsequent lines
-    start in the zeroth column.
-  * The `@docs` keyword starts a list of values that are inlined in [the
-    resulting documentation](/packages/elm-lang/core/latest/Maybe).
-  * Functions are grouped into related units with titles
+  * The first line starts after a single space, and all subsequent
+    lines are aligned all the way to the left.
+  * The `@docs` keyword precedes a comma-separated list of values that
+    are inlined in [the resulting
+    documentation](/packages/elm-lang/core/latest/Maybe).
+  * Functions are grouped into related units with titles, declared in
+    Markdown. Sometimes it's appropriate to put a little text under
+    the title associated with the group but not any one function.
   * Although documentation for each function should be self-contained,
     things are ordered intelligently. Assume people will read through
-    linearly and try to make the document structure ideal for learning
+    linearly, so try to make the document structure ideal for learning
     the API. You need to understand the Maybe data type to understand
-    anything else, so it appears first. `maybe` is an important function
-    so it appears early on. Etc.
+    anything else, so it appears first. `withDefault` is an important
+    function so it appears early on. And so forth.
 
-Again, the goal is to have consistency, so readers can glance through easily
-and writers do not need to argue about style.
+Again, the goal is to have consistency, so readers can glance through
+easily and writers do not need to argue about style.
+
+Finally, modules need to be listed as exposed in `elm-package.json`.
+Some of the compiler's rules about the documentation format will only
+be enforced for these modules.
 
 """

--- a/frontend/Page/DocumentationFormat.elm
+++ b/frontend/Page/DocumentationFormat.elm
@@ -47,7 +47,7 @@ documentation for complete examples.
 
 Here is an example from [the `String` library](/packages/elm-lang/core/latest/String):
 
-```haskell
+```elm
 {-| Convert a list of characters into a String. Can be useful if you
 want to create a string primarly by consing, perhaps for decoding
 something.
@@ -78,7 +78,7 @@ and writers do not need to argue about style.
 
 Here is the module documentation for [the `Maybe` library](/packages/elm-lang/core/latest/Maybe):
 
-```haskell
+```elm
 module Maybe (Maybe(Just,Nothing), andThen, map, withDefault, oneOf) where
 
 {-| This library fills a bunch of important niches in Elm. A `Maybe` can help


### PR DESCRIPTION
Documentation format: update the Maybe example to match the 0.15 implementation,
add a few other notes, general copyediting.

Design Guidelines: Update to newest terminology (no more open imports and ADTs),
greatly expand one section to talk about opaque types, why they're useful, and
how to create them, and more general copyediting.

As usual I can address any concerns you may have.