### PR TITLE
Use a regex to strip qualifiers

### DIFF
--- a/frontend/Component/Documentation.elm
+++ b/frontend/Component/Documentation.elm
@@ -8,6 +8,7 @@ import Json.Decode exposing (..)
 import Markdown
 import String
 import Text
+import Regex
 
 import ColorScheme as C
 
@@ -299,9 +300,7 @@ viewFunctionType tipe =
 
 typeToText : String -> Text.Text
 typeToText tipe =
-  String.words tipe
-    |> List.map dropQualifier
-    |> String.join " "
+  dropQualifier tipe
     |> String.split "->"
     |> List.map prettyColons
     |> List.intersperse (green "->")
@@ -318,20 +317,8 @@ prettyColons tipe =
 
 dropQualifier : String -> String
 dropQualifier token =
-  Maybe.withDefault token (last (String.split "." token))
-
-
-last : List a -> Maybe a
-last list =
-  case list of
-    [] ->
-      Nothing
-
-    [x] ->
-      Just x
-
-    _ :: xs ->
-      last xs
+  let qualifiers = Regex.regex "[A-Za-z1-9_]*\\."
+  in Regex.replace Regex.All qualifiers (always "") token
 
 
 -- VIEW HELPERS


### PR DESCRIPTION
This _should_ fix #46 but I haven't been able to build either the package site or the elm components, so please pull this down and ensure that it works. In particular, I still have no idea why the original `()` to `)` problem was occurring, just the `(Set.Set` becoming `Set` part.