### PR TITLE
turn commas green in tuples and records

### DIFF
--- a/frontend/Component/Documentation.elm
+++ b/frontend/Component/Documentation.elm
@@ -301,7 +301,7 @@ viewFunctionType modules tipe =
 typeToText : List String -> String -> Text.Text
 typeToText modules =
   replaceMap " " (Text.fromString " ")
-    <| replaceMap "," (Text.fromString ",")
+    <| replaceMap "," (green ",")
     <| replaceMap "(" (Text.fromString "(")
     <| replaceMap ")" (Text.fromString ")")
     <| replaceMap "{" (Text.fromString "{")


### PR DESCRIPTION
... in the shown type signatures. Mirrors what happens with other separators, like `|` for union types or `->` in function types.