### PR TITLE
Added type annotation to make newer GHC happy

### DIFF
--- a/backend/Routes.hs
+++ b/backend/Routes.hs
@@ -242,7 +242,7 @@ splitDocs directory =
         Nothing -> throwError "The uploaded documentation is invalid."
         Just docs ->
           liftIO $
-            forM_ docs $ \doc ->
+            forM_ (docs :: [Docs.Documentation]) $ \doc ->
               do  let name = Module.hyphenate (Docs.moduleName doc)
                   let docPath = directory </> "docs" </> name <.> "json"
                   createDirectoryIfMissing True (directory </> "docs")


### PR DESCRIPTION
Without that annotation, the new compiler complained about an unclear `Foldable` instance. Has to do with GHC's recent move toward typing many originally list functions (like `forM_`) more generically via `Foldable`. (The [Burning-Bridges-Incident](https://ghc.haskell.org/trac/ghc/ticket/9586).)