### PR TITLE
Enable search for constructor names

### DIFF
--- a/frontend/Component/Documentation.elm
+++ b/frontend/Component/Documentation.elm
@@ -55,10 +55,13 @@ valueList =
     nameList =
       list ("name" := string)
 
+    constructorList =
+      list (tuple2 always string (list string))
+
     allNames =
-      object3 (\x y z -> x ++ y ++ z)
+      object3 (\x y z -> x ++ List.concat y ++ z)
         ("aliases" := nameList)
-        ("types" := nameList)
+        ("types" := list (object2 (::) ("name" := string) ("cases" := constructorList)))
         ("values" := nameList)
   in
     object2 (,) ("name" := string) allNames

--- a/frontend/Component/Documentation.elm
+++ b/frontend/Component/Documentation.elm
@@ -49,7 +49,7 @@ documentation =
     ("values" := list value)
 
 
-valueList : Decoder (String, List String)
+valueList : Decoder (String, List (String, String))
 valueList =
   let
     nameList =
@@ -60,9 +60,9 @@ valueList =
 
     allNames =
       object3 (\x y z -> x ++ List.concat y ++ z)
-        ("aliases" := nameList)
-        ("types" := list (object2 (::) ("name" := string) ("cases" := constructorList)))
-        ("values" := nameList)
+        ("aliases" := Json.Decode.map (List.map (\n -> (n, n))) nameList)
+        ("types" := list (object2 (\n cs -> List.map ((,) n) (n :: cs)) ("name" := string) ("cases" := constructorList)))
+        ("values" := Json.Decode.map (List.map (\n -> (n, n))) nameList)
   in
     object2 (,) ("name" := string) allNames
 

--- a/frontend/Component/Documentation.elm
+++ b/frontend/Component/Documentation.elm
@@ -61,7 +61,9 @@ valueList =
     allNames =
       object3 (\x y z -> x ++ List.concat y ++ z)
         ("aliases" := Json.Decode.map (List.map (\n -> (n, n))) nameList)
-        ("types" := list (object2 (\n cs -> List.map ((,) n) (n :: cs)) ("name" := string) ("cases" := constructorList)))
+        ("types" := list (object2 (\n cs -> List.map ((,) n) (n :: List.filter ((/=) n) cs))
+                            ("name" := string)
+                            ("cases" := constructorList)))
         ("values" := Json.Decode.map (List.map (\n -> (n, n))) nameList)
   in
     object2 (,) ("name" := string) allNames

--- a/frontend/Component/Package/ModuleList.elm
+++ b/frontend/Component/Package/ModuleList.elm
@@ -12,7 +12,7 @@ type alias Model =
     , name : String
     , version : String
     , versionList : List String
-    , modules : List (String, List String)
+    , modules : List (String, List (String, String))
     }
 
 
@@ -41,11 +41,11 @@ view w searchTerm model =
         _ -> flow down (List.map (viewModule w (toUrl model) searchStatus) modules)
 
 
-viewModule : Int -> String -> SearchStatus -> (String, List String) -> Element
+viewModule : Int -> String -> SearchStatus -> (String, List (String, String)) -> Element
 viewModule width rootUrl searchStatus (moduleName, values) =
     let url = rootUrl ++ "/" ++ String.map (\c -> if c == '.' then '-' else c) moduleName
-        viewValue name =
-            link width (url ++ "#" ++ name) "  " (Text.monospace (Text.fromString name))
+        viewValue (anchor, name) =
+            link width (url ++ "#" ++ anchor) "  " (Text.monospace (Text.fromString name))
 
         name = link width url "" (Text.fromString moduleName)
     in
@@ -69,14 +69,14 @@ notFound term =
     |> leftAligned
 
 
-search : String -> List (String, List String) -> List (String, List String)
+search : String -> List (String, List (String, String)) -> List (String, List (String, String))
 search searchTerm modules =
   List.filterMap (searchModule searchTerm) modules
 
 
-searchModule : String -> (String, List String) -> Maybe (String, List String)
+searchModule : String -> (String, List (String, String)) -> Maybe (String, List (String, String))
 searchModule searchTerm (moduleName, values) =
-  case List.filter (String.contains searchTerm << String.toLower) values of
+  case List.filter (String.contains searchTerm << String.toLower << snd) values of
     [] ->
         if String.contains searchTerm (String.toLower moduleName)
           then Just (moduleName, [])

--- a/frontend/Page/Package.elm
+++ b/frontend/Page/Package.elm
@@ -62,7 +62,7 @@ moduleList =
   Signal.mailbox (packageInfo [])
 
 
-packageInfo : List (String, List String) -> ModuleList.Model
+packageInfo : List (String, List (String, String)) -> ModuleList.Model
 packageInfo modules =
   ModuleList.Model context.user context.name context.version context.versionList modules
 


### PR DESCRIPTION
Implements https://github.com/elm-lang/package.elm-lang.org/issues/73.

For example, searching for "ok" in `core` will now lead to:
![screen](https://cloud.githubusercontent.com/assets/5853832/9422839/a475ee62-48a6-11e5-9059-cdf27862b244.png)
where the `Ok` on the left will be a link to http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Result#Result, i.e., to the union type defining that constructor.

(Previously/currently, searching for "ok" in `core` would give no results at all.)