### PR TITLE
Make outdated package version warning more explicit

### DIFF
--- a/frontend/Component/Header.elm
+++ b/frontend/Component/Header.elm
@@ -50,8 +50,9 @@ view versionChan innerWidth user package version versions maybeModule =
       else
         [ color C.lightGrey (spacer innerWidth 1)
         , container innerWidth 40 middle <| centered <|
-            Text.fromString "Warning! The latest version of this package is "
+            Text.fromString "Warning! You are looking at an outdated version of this package. The latest version is "
             ++ Text.link ("/packages/" ++ user ++ "/" ++ package ++ "/" ++ latestVersion) (Text.fromString latestVersion)
+            ++ Text.fromString "."
         ]
   in
     flow down <|


### PR DESCRIPTION
Motivated by https://www.reddit.com/r/elm/comments/3kf04y/outdated_tutorials/, which suggests that the previous warning was overlooked. (It did not actually say that the version being looked at was outdated. It only said what the newest version is.)