### PR TITLE
Move moduleName to front of title / tab in generated docs

### DIFF
--- a/frontend/Page/Module.elm
+++ b/frontend/Page/Module.elm
@@ -19,7 +19,7 @@ port context : { user : String, name : String, version : String, versionList : L
 
 port title : String
 port title =
-    context.moduleName ++ " " ++ context.user ++ "/" ++ context.name ++ context.version 
+    context.moduleName ++ " " ++ context.user ++ "/" ++ context.name ++ " " ++ context.version 
 
 
 packageUrl : String -> String


### PR DESCRIPTION
Currently moduleName is last (after context.user, name, version), so it gets chopped off first with multiple tabs.
![image](https://cloud.githubusercontent.com/assets/8269863/9866021/0ab7baf0-5b23-11e5-8205-a114224a024c.png)

This PR moves moduleName to front, so it is the last to get chopped.