### PR TITLE
Removed spaces in package title on package page

### DIFF
--- a/frontend/Component/Header.elm
+++ b/frontend/Component/Header.elm
@@ -23,7 +23,7 @@ view versionChan innerWidth user package version versions maybeModule =
             (Text.fromString package)
 
     userPackageText =
-      userLink ++ Text.fromString " / " ++ packageLink
+      userLink ++ Text.fromString "/" ++ packageLink
 
     headerText =
       case maybeModule of


### PR DESCRIPTION
Currently the author/package title is displayed in a way that prevents one from being able to copy and paste it into a terminal and execute a command such as `elm-package install`. You must paste it and then go back and remove the spaces. This is less than ideal. I have removed the spaces.