### PR TITLE
Show ambiguous types fully qualified

### DIFF
--- a/frontend/Component/Module.elm
+++ b/frontend/Component/Module.elm
@@ -18,7 +18,7 @@ view versionAddr innerWidth user package version versionList modules mentionedTy
     [ Header.view versionAddr innerWidth user package version versionList (Just docs.name)
     , color C.lightGrey (spacer innerWidth 1)
     , spacer innerWidth 12
-    , viewDocs innerWidth (D.toDocDict modules docs) docs.comment
+    , viewDocs innerWidth (D.toDocDict modules mentionedTypes docs) docs.comment
     ]
 
 

--- a/frontend/Component/Module.elm
+++ b/frontend/Component/Module.elm
@@ -12,8 +12,8 @@ import Component.Documentation as D
 import Component.Header as Header
 
 
-view : Signal.Address String -> Int -> String -> String -> String -> List String -> List String -> D.Documentation -> Element
-view versionAddr innerWidth user package version versionList modules docs =
+view : Signal.Address String -> Int -> String -> String -> String -> List String -> List String -> List (String, String) -> D.Documentation -> Element
+view versionAddr innerWidth user package version versionList modules mentionedTypes docs =
     flow down
     [ Header.view versionAddr innerWidth user package version versionList (Just docs.name)
     , color C.lightGrey (spacer innerWidth 1)


### PR DESCRIPTION
Addresses https://github.com/elm-lang/package.elm-lang.org/issues/67.

As an example of the effect:

Where previously http://package.elm-lang.org/packages/Apanatshka/elm-signal-extra/5.6.0/Signal-Time#Time looks like this:
![before](https://cloud.githubusercontent.com/assets/5853832/10250954/16f69908-692e-11e5-9941-aa813b4d32bf.png)
now with this pull request it will look like this:
![after](https://cloud.githubusercontent.com/assets/5853832/10250972/2551303a-692e-11e5-85b1-b4d3a182c34e.png)
