### PR TITLE
Ensure module lists are sorted by name

### DIFF
--- a/frontend/Page/Package.elm
+++ b/frontend/Page/Package.elm
@@ -52,7 +52,7 @@ port getModuleList =
       Task.succeed []
 
     send list =
-      Signal.send moduleList.address (packageInfo list)
+      Signal.send moduleList.address (packageInfo (List.sort list))
   in
     (get `onError` recover) `andThen` send
 


### PR DESCRIPTION
On the development version of the packages page, we currently have:
![old](https://cloud.githubusercontent.com/assets/5853832/10427847/3124b988-70ed-11e5-8c5d-967811de787b.png)
but:
![new](https://cloud.githubusercontent.com/assets/5853832/10427851/35962b64-70ed-11e5-8199-41e2671ede16.png)

The apparent reason is that in http://package.elm-lang.org/packages/elm-lang/core/2.1.0/documentation.json the modules are stored in alphabetic order, whereas in the corresponding version for 3.0.0 on the development server, there is no such order.

It does make sense to not make any assumptions on the order in `documentation.json` and instead simply do a sort (on the module names as key) after reading that file in.