### PR TITLE
Remove splitDocs

### DIFF
--- a/src/backend/Routes.hs
+++ b/src/backend/Routes.hs
@@ -2,11 +2,9 @@
 module Routes where
 
 import Control.Applicative
-import Control.Monad.Except (ExceptT, forM_, runExceptT, liftIO, throwError, when)
-import qualified Data.Aeson as Json
+import Control.Monad.Except (ExceptT, runExceptT, liftIO, throwError, when)
 import qualified Data.Binary as Binary
 import qualified Data.ByteString.Char8 as BS
-import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Either as Either
 import qualified Data.List as List
 import qualified Data.Map as Map
@@ -18,7 +16,6 @@ import System.Directory
 import System.FilePath
 
 import qualified Elm.Compiler.Module as Module
-import qualified Elm.Docs as Docs
 import qualified Elm.Package as Pkg
 import qualified Elm.Package.Description as Desc
 import qualified Elm.Package.Paths as Path

--- a/src/backend/Routes.hs
+++ b/src/backend/Routes.hs
@@ -126,9 +126,8 @@ register =
       description <- Desc.read (directory </> Path.description)
 
       result <-
-          liftIO $ runExceptT $ do
+          liftIO $ runExceptT $
             verifyWhitelist (Desc.natives description) (Desc.name description)
-            splitDocs directory
 
       case result of
         Right () ->
@@ -249,21 +248,6 @@ writePartError part =
 
       Left exception ->
           writeText (policyViolationExceptionReason exception)
-
-
-splitDocs :: FilePath -> ExceptT String IO ()
-splitDocs directory =
-  do  json <- liftIO (LBS.readFile (directory </> documentationPath))
-      case Json.decode json of
-        Nothing -> throwError "The uploaded documentation is invalid."
-        Just docs ->
-          liftIO $
-            forM_ (docs :: [Docs.Documentation]) $ \doc ->
-              do  let name = Module.hyphenate (Docs.moduleName doc)
-                  let docPath = directory </> "docs" </> name <.> "json"
-                  createDirectoryIfMissing True (directory </> "docs")
-                  LBS.writeFile docPath (Json.encode doc)
-
 
 
 -- FETCH ALL AVAILABLE VERSIONS


### PR DESCRIPTION
See https://github.com/elm-lang/package.elm-lang.org/issues/98. It seems that redundancy is now removed, but the `docs/*.json` files are still being produced (but never used). This PR gets rid of them for the future.

After accepting this PR here, the `FromJSON` instance for `Type` over in https://github.com/elm-lang/elm-compiler should be dead code. Removing it then, would also fix this issue: https://github.com/elm-lang/elm-compiler/issues/1076.