### PR TITLE
Horizontal scroll for code blocks

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -35,7 +35,7 @@ pre {
   border-width: 1px;
   border-color: rgb(245,245,245);
   border-radius: 6px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 


### PR DESCRIPTION
Use `auto` overflow to show scrollbar only if wider.