### PR TITLE
Catalog search now handles spaces

### DIFF
--- a/src/frontend/Component/Catalog.elm
+++ b/src/frontend/Component/Catalog.elm
@@ -76,12 +76,19 @@ searchFor : String -> List Summary.Summary -> List Summary.Summary
 searchFor query summaries =
   let
     lowerQuery =
-      String.toLower query
+      String.toLower query |> String.words
 
     contains {name,summary} =
-      String.contains lowerQuery (String.toLower name)
-      ||
-      String.contains lowerQuery (String.toLower summary)
+      let
+        lowerName = String.toLower name
+        lowerSummary = String.toLower summary
+      in
+        List.all
+          (\word ->
+            String.contains word lowerName
+            ||
+            String.contains word lowerSummary)
+          lowerQuery
   in
     List.filter contains summaries
 


### PR DESCRIPTION
Previously any search with a space (surrounded by non-spaces) would return no results. This simple change returns libraries that string match each word of the query.