### PR TITLE
Fix package docs discarding commas

### DIFF
--- a/src/frontend/Component/PackageDocs.elm
+++ b/src/frontend/Component/PackageDocs.elm
@@ -233,7 +233,12 @@ toChunks moduleDocs =
 
 subChunks : Docs.Module -> String -> List (Chunk String)
 subChunks moduleDocs postDocs =
-    subChunksHelp moduleDocs (String.split "," postDocs)
+    case Regex.split (Regex.AtMost 1) (Regex.regex "\n") postDocs of
+      [] ->
+        Debug.crash "Expected a newline between @docs statements!"
+
+      firstChunk :: rest ->
+        (subChunksHelp moduleDocs (String.split "," firstChunk)) ++ List.map Markdown rest
 
 
 subChunksHelp : Docs.Module -> List String -> List (Chunk String)

--- a/src/frontend/Component/PackageDocs.elm
+++ b/src/frontend/Component/PackageDocs.elm
@@ -238,7 +238,32 @@ subChunks moduleDocs postDocs =
         Debug.crash "Expected a newline between @docs statements!"
 
       firstChunk :: rest ->
-        (subChunksHelp moduleDocs (String.split "," firstChunk)) ++ List.map Markdown rest
+        let
+          handleRest =
+            if String.endsWith "," (String.trimRight firstChunk)
+            then multiLineDocsChunk moduleDocs
+            else List.map Markdown
+        in
+          subChunksHelp moduleDocs (String.split "," firstChunk) ++ handleRest rest
+
+
+multiLineDocsChunk : Docs.Module -> List String -> List (Chunk String)
+multiLineDocsChunk moduleDocs docsToParse =
+  let
+    errMsg =
+      "Found an @docs listing that ended with a comma, but found no more docs on the next line!"
+  in
+    case docsToParse of
+      [] ->
+        Debug.crash errMsg
+
+      [rest] ->
+        if String.startsWith "\n" rest || String.startsWith "#" rest
+        then Debug.crash errMsg
+        else subChunks moduleDocs rest
+
+      _ ->
+        Debug.crash "This shouldn't happen: the Regex was only supposed to take one line"
 
 
 subChunksHelp : Docs.Module -> List String -> List (Chunk String)

--- a/src/frontend/Component/PackageDocs.elm
+++ b/src/frontend/Component/PackageDocs.elm
@@ -240,9 +240,10 @@ subChunks moduleDocs postDocs =
       firstChunk :: rest ->
         let
           handleRest =
-            if String.endsWith "," (String.trimRight firstChunk)
-            then multiLineDocsChunk moduleDocs
-            else List.map Markdown
+            if String.endsWith "," (String.trimRight firstChunk) then
+              multiLineDocsChunk moduleDocs
+            else
+              List.map Markdown
         in
           subChunksHelp moduleDocs (String.split "," firstChunk) ++ handleRest rest
 
@@ -258,9 +259,10 @@ multiLineDocsChunk moduleDocs docsToParse =
         Debug.crash errMsg
 
       [rest] ->
-        if String.startsWith "\n" rest || String.startsWith "#" rest
-        then Debug.crash errMsg
-        else subChunks moduleDocs rest
+        if String.startsWith "\n" rest || String.startsWith "#" rest then
+          Debug.crash errMsg
+        else
+          subChunks moduleDocs rest
 
       _ ->
         Debug.crash "This shouldn't happen: the Regex was only supposed to take one line"


### PR DESCRIPTION
Turns out to be a simple fix: treat the line with the `@docs` as having docs, and throw the rest in a markdown node.

@evancz this fixes #121. Also this is affecting core [here](http://package.elm-lang.org/packages/elm-lang/core/3.0.0/Basics#comparison) and possibly other places too.

Notes:

* We need to use the regex rather than `String.lines` because otherwise paragraphs are broken by commas into separate markdown blocks, which are new lines with vertical spacing.
* It's possible `subChunksHelp` can be simplified now that it's assured everything is on the same line as an `@docs`.
* If you spread your `@docs` declarations over multiple lines, only the first line works. I think this is reasonable.
*I've never seen an `@docs`, and empty line, and then another `@docs`, but if you did it I think you'd end up with a markdown block that is empty. Virtually always `@docs` lines are separated by a header so I don't think it will be a problem.