### PR TITLE
Show all entries for matched modules in search

### DIFF
--- a/src/frontend/Component/PackageSidebar.elm
+++ b/src/frontend/Component/PackageSidebar.elm
@@ -192,8 +192,8 @@ viewSearchDict context query searchDict =
 
       searchResults =
         searchDict
-          |> Dict.map (\_ values -> List.filter (.name >> containsQuery) values)
-          |> Dict.filter (\key values -> not (List.isEmpty values) || containsQuery key)
+          |> Dict.map (\key values -> if containsQuery key then values else List.filter (.name >> containsQuery) values)
+          |> Dict.filter (\_ values -> not (List.isEmpty values))
           |> Dict.toList
     in
       ul [] (List.map (viewModuleLinks context) searchResults)


### PR DESCRIPTION
As explained [here](https://github.com/elm-lang/package.elm-lang.org/issues/133#issuecomment-160266271), I think it makes more sense to present links for all subentries of a module that matches the search term on a package's page.

From over there:
> Otherwise, the UI experience seems to become inconsistent. Right now, when I have put something into the search box, I know that I don't have to click on the module links, because anything that is relevant for my query will appear as links a level deeper. This expectation is broken if for "rand..." I do get the `Random` link, but not the `Random.bool`, `Random.int` etc. sub-links.
>
> And I'd even go a bit further. Let's say I have seen `Color.black` mentioned somewhere, and want to find it. So on the `core` package page, I start typing "color.black" into the search box. (There is no reason for me really to know that I shouldn't do that. That I should only type "black", not "color.black" as I have seen mentioned somewhere.) The current behavior is that I never get to see the actual link to `Color.black`.

This PR fixes the behavior. For example, if I type "random" into the search box, I now get this:
![unbenannt](https://cloud.githubusercontent.com/assets/5853832/11457796/c0048832-96b2-11e5-9c71-704c8c69a5f2.png)
instead of just the "Random" link.

I think this is preferable. If I know I'm looking for the docs of `Random.generate`, I want to be able to:
* go to the `core` package, type "random" into the box, get a link to `Random.generate` I can click,

instead of:
* go to the `core` package, type "random" into the box, get a lone link to `Random` that I have to click, to then go linearly through the `Random` module page to find `generate` somewhere in there.
