### PR TITLE
better handle docs 'comment' sections/parts

### DIFF
--- a/src/frontend/Component/PackageDocs.elm
+++ b/src/frontend/Component/PackageDocs.elm
@@ -222,13 +222,28 @@ viewChunk entryView chunk =
 
 toChunks : Docs.Module -> List (Chunk String)
 toChunks moduleDocs =
-  case String.split "\n@docs " moduleDocs.comment of
-    [] ->
-        Debug.crash "Expecting some documented functions in this module!"
+  let
+  sections =
+    String.split "\n\n" moduleDocs.comment
 
-    firstChunk :: rest ->
+  process section =
+    case String.split "\n@docs " section of
+      [] ->
+        []
+
+      [text] ->
+        [Markdown text]
+
+      firstChunk :: rest ->
         Markdown firstChunk
         :: List.concatMap (subChunks moduleDocs) rest
+
+  in
+    if List.isEmpty sections then
+      Debug.crash "Expecting some documented functions in this module!"
+
+    else
+      List.concatMap process sections
 
 
 subChunks : Docs.Module -> String -> List (Chunk String)
@@ -303,4 +318,3 @@ toEntry moduleDocs name =
 
     Just entry ->
         Entry entry
-


### PR DESCRIPTION
Better handling for markdown text sections in docs "comment" data.

Fixes this:
https://github.com/elm-lang/package.elm-lang.org/issues/121

While keeping support for complex cases like:
https://github.com/evancz/elm-html/blob/master/src/Html/Attributes.elm#L42-L44
https://github.com/elm-lang/package.elm-lang.org/pull/127#issuecomment-167355323

Code Reviews are happily welcomed