### PR TITLE
Add elm-community/elm-linear-algebra to native whitelist

### DIFF
--- a/native-whitelist.json
+++ b/native-whitelist.json
@@ -1,6 +1,7 @@
 [
     "coreytrampe/elm-vendor",
     "elm-community/elm-history",
+    "elm-community/elm-linear-algebra",
     "elm-lang/core",
     "evancz/elm-effects",
     "evancz/elm-http",


### PR DESCRIPTION
As explained in https://github.com/elm-lang/package.elm-lang.org/issues/149#issuecomment-168164677, nothing new needs to be approved here, but still the package cannot be published unless explicitly whitelisted. 