### PR TITLE
Link to active webgl fork

### DIFF
--- a/src/frontend/Component/CatalogSidebar.elm
+++ b/src/frontend/Component/CatalogSidebar.elm
@@ -89,7 +89,7 @@ renderingPackages =
   [ "evancz" => "elm-html"
   , "evancz" => "elm-svg"
   , "evancz" => "elm-markdown"
-  , "johnpmayer" => "elm-webgl"
+  , "elm-community" => "elm-webgl"
   ]
 
 


### PR DESCRIPTION
The catalog sidebar links to an outdated version of elm-webgl. I updated it to point to elm-community/elm-webgl