### PR TITLE
Optimize the spacing of version dots on the timeline

### DIFF
--- a/src/frontend/Overview/Constants.elm
+++ b/src/frontend/Overview/Constants.elm
@@ -1,9 +1,14 @@
 module Overview.Constants
   ( toX
   , toFraction
+  , activeWidth
+  , dotBorderThickness
+  , dotSize
+  , DotMetrics(WithBorder, WithoutBorder)
   )
   where
 
+import Docs.Version as Vsn
 
 
 -- CONSTANTS
@@ -19,9 +24,36 @@ padding =
   30
 
 
+-- TIMELINE DOTS
+
+dotBorderThickness : Int
+dotBorderThickness =
+  4
+
+
+type DotMetrics
+  = WithBorder
+  | WithoutBorder
+
+
+dotSize : Vsn.Magnitude -> DotMetrics -> Int
+dotSize magnitude metrics =
+  let
+    nakedSize =
+      case magnitude of
+        Vsn.Major -> 24
+        Vsn.Minor -> 12
+        Vsn.Patch -> 10
+
+    borderSize =
+      case metrics of
+        WithBorder -> dotBorderThickness
+        WithoutBorder -> 0
+  in
+    nakedSize + borderSize
+
 
 -- CONVERSIONS
-
 
 activeWidth : Float
 activeWidth =

--- a/src/frontend/Overview/History.elm
+++ b/src/frontend/Overview/History.elm
@@ -205,28 +205,37 @@ px n =
 
 major : List (String, String)
 major =
-  [ "background-color" => "#eeeeee"
-  , "border" => "4px solid #bbbbbb"
-  , "width" => "20px"
-  , "height" => "20px"
-  , "line-height" => "20px"
-  , "font-size" => "14px"
-  ]
+  let
+    size = Constants.dotSize Vsn.Major Constants.WithoutBorder
+  in
+    [ "background-color" => "#eeeeee"
+    , "border" => ((px Constants.dotBorderThickness) ++ " solid #bbbbbb")
+    , "width" => px size
+    , "height" => px size
+    , "line-height" => px size
+    , "font-size" => "14px"
+    ]
 
 
 minor : List (String, String)
 minor =
-  [ "background-color" => "#eeeeee"
-  , "border" => "4px solid #bbbbbb"
-  , "width" => "8px"
-  , "height" => "8px"
-  ]
+  let
+    size = Constants.dotSize Vsn.Minor Constants.WithoutBorder
+  in
+    [ "background-color" => "#eeeeee"
+    , "border" => ((px Constants.dotBorderThickness) ++ " solid #bbbbbb")
+    , "width" => px size
+    , "height" => px size
+    ]
 
 
 patch : List (String, String)
 patch =
-  [ "background-color" => "#bbbbbb"
-  , "width" => "10px"
-  , "height" => "10px"
-  ]
+  let
+    size = Constants.dotSize Vsn.Patch Constants.WithoutBorder
+  in
+    [ "background-color" => "#bbbbbb"
+    , "width" => px size
+    , "height" => px size
+    ]
 

--- a/src/frontend/Utils/ProximityTree.elm
+++ b/src/frontend/Utils/ProximityTree.elm
@@ -5,9 +5,11 @@ module Utils.ProximityTree
     , map
     , lookup
     , nearest
+    , optimizeSpacing
     )
     where
 
+import Utils.ProximityTree.Optimizer as ProxOptimizer
 
 
 -- DEFINITION
@@ -74,7 +76,6 @@ fromListHelp list =
         Node (Entry fraction value) (fromListHelp left) (fromListHelp right)
 
 
-
 -- FLATTEN
 
 
@@ -90,6 +91,12 @@ toList tree =
 
 
 -- UTILITIES
+
+optimizeSpacing : (a -> Float) -> ProximityTree a -> ProximityTree a
+optimizeSpacing toDesiredSpacing tree =
+  toList tree
+    |> ProxOptimizer.layout toDesiredSpacing
+    |> fromListHelp
 
 
 map : (a -> b) -> ProximityTree a -> ProximityTree b

--- a/src/frontend/Utils/ProximityTree/Optimizer.elm
+++ b/src/frontend/Utils/ProximityTree/Optimizer.elm
@@ -1,0 +1,179 @@
+module Utils.ProximityTree.Optimizer
+    ( layout
+    )
+    where
+
+
+type alias Edge = Float
+
+
+type alias Node a =
+  { payload : a
+  , minRightSpacing : Float
+  }
+
+
+-- a list of items and their relative distances to the following item
+type alias ProximityGraph a =
+  List (Node a, Maybe Edge)
+
+
+layout : (a -> Float) -> List (Float, a) -> List (Float, a)
+layout toDesiredSpacing list =
+  list
+    |> fromList toDesiredSpacing
+    |> reflow 0.0
+    |> shrinkIfNecessary softShrink
+    |> shrinkIfNecessary hardShrink
+    |> toList
+
+
+fromList : (a -> Float) -> List (Float, a) -> ProximityGraph a
+fromList toDesiredSpacing list =
+  if List.isEmpty list then
+    []
+  else
+    let
+      (fractions, values) =
+        List.unzip list
+
+      nextFractions =
+        (List.map Just fractions) ++ [Nothing]
+          |> List.drop 1
+
+      spacings =
+        List.map toDesiredSpacing values
+
+      nextSpacings =
+        spacings ++ [0.0]
+          |> List.drop 1
+    in
+      List.map5 makeEntry spacings nextSpacings values fractions nextFractions
+
+
+makeEntry : Float -> Float -> a -> Float -> Maybe Float -> (Node a, Maybe Edge)
+makeEntry spacing nextSpacing value fraction nextFraction =
+  ( Node value (0.5 * (spacing + nextSpacing))
+  , Maybe.map2 (-) nextFraction (Just fraction)
+  )
+
+
+reflow : Float -> ProximityGraph a -> ProximityGraph a
+reflow debt graph =
+  case graph of
+    [] ->
+      []
+
+    ((_, Nothing) as entry) :: rest ->
+      entry :: rest
+
+    (node, Just right) :: rest ->
+      let
+        adjustedRight =
+          right - debt
+
+        want =
+          max 0.0 (node.minRightSpacing - adjustedRight)
+
+        newNode =
+          ( node
+          , Just (adjustedRight + want)
+          )
+      in
+        newNode :: reflow want rest
+
+
+amountToShrink : ProximityGraph a -> Maybe Float
+amountToShrink graph =
+  let
+    distances =
+      List.map (rightEdge >> Maybe.withDefault 0.0) graph
+
+    overflow =
+      List.sum distances - 1.0
+  in
+    if overflow > 0.0000001 then Just overflow else Nothing
+
+
+shrinkIfNecessary : (Float -> ProximityGraph a -> ProximityGraph a) -> ProximityGraph a -> ProximityGraph a
+shrinkIfNecessary shrinker graph =
+  case amountToShrink graph of
+    Nothing ->
+      graph
+
+    Just overflow ->
+      shrinker overflow graph
+
+
+-- soft because it collapses space without causing overlap
+softShrink : Float -> ProximityGraph a -> ProximityGraph a
+softShrink overflow graph =
+  case graph of
+    [] ->
+      []
+
+    ((_, Nothing) as entry) :: rest ->
+      entry :: softShrink overflow rest
+
+    (node, Just right) :: rest ->
+      let
+        excess =
+          max 0.0 (right - node.minRightSpacing)
+
+        want =
+          min excess overflow
+
+        remainingOverflow =
+          overflow - want  
+
+        newNode =
+          ( node
+          , Just (right - want)
+          )
+      in
+        newNode :: softShrink remainingOverflow rest
+
+
+-- hard because it may result in overlap (use this as a last resort)
+hardShrink : Float -> ProximityGraph a -> ProximityGraph a
+hardShrink overflow graph =
+  let
+    adjustment =
+      overflow / (toFloat (List.length graph))
+
+    adjuster (node, maybeEdge) =
+      ( node
+      , Maybe.map2 (-) maybeEdge (Just adjustment)
+      )
+  in
+    List.map adjuster graph
+
+
+toList : ProximityGraph a -> List (Float, a)
+toList graph =
+  let
+    adder a b =
+      b + (Maybe.withDefault 0.0 a)
+
+    fractions =
+      List.scanl
+        adder
+        0.0
+        (List.map rightEdge graph)
+
+    values =
+      List.map (node >> .payload) graph
+  in
+    List.map2 (,) fractions values
+
+
+-- UTILITY
+
+node : (Node a, Maybe Edge) -> Node a
+node (node, _) =
+  node
+
+
+rightEdge : (Node a, Maybe Edge) -> Maybe Edge
+rightEdge (_, right) =
+  right


### PR DESCRIPTION
@evancz here is my attempt at solving the package API diff timeline overlap problem.

This change optimizes the spacing of dots on the timeline so that the natural chronology is preserved as much as possible, while still giving each version enough space. If there are simply too many dots
to be displayed in the allotted space, the algorithm will uniformly squish everything to fit. This should only be necessary in pathological cases (e.g. a package which has over 20 releases).

## Backstory
The timeline is displayed at a fixed-width, but the variety of Elm packages may have anywhere from one version to tens of versions. This may lead to undesirable overlap of the dots that represent versions
in various common and not-so-common scenarios.

## How it Works
The key to the algorithm is representing the timeline as a list of relative distances. For each version/dot, we store the distance to the ADJACENT dot rather than the offset from the timeline origin.
This allows us to easily to make room for a dot by simply adjusting one relative number without requiring a rippling change to each downstream element.

### Algorithm
1. convert from the ProximityTree's representation of normalized fractions measured from the origin to relative, adjacent distance
2. from left-to-right, adjust each element so that it has at least its minimum space, stealing from downstream as necessary
3. after reaching the end, if the sum of the relative distances is greater than 1, then we exceeded the fixed width and we need to shrink
4. apply a "soft" shrink: proceeding from left-to-right COLLAPSE as much empty space as you can without violating any minimum distances until the overflow is consumed or we reach the end
5. if there is STILL overflow, apply a "hard" shrink: uniformly scaling-down the entire timeline so that the last version fits the fixed width
6. convert back to ProximityTree

# Results
Before and after screenshots for the 5 example packages provided in `tmp/*.html`

## Before
<img width="845" alt="before" src="https://cloud.githubusercontent.com/assets/84525/12635893/e9620188-c53c-11e5-9ceb-425e136f317d.png">

## After
<img width="845" alt="after" src="https://cloud.githubusercontent.com/assets/84525/12635894/ec92b97e-c53c-11e5-9beb-d5a5651bca40.png">

# Testing it out
Just follow the directions from `tmp/README.md` to build `Page.PackageOverview`.

# Additional Notes

This is my first time writing any Elm code—enjoyed it quite a bit, by the way—and so any feedback about code style, naming or structure would be appreciated.