### PR TITLE
Fix HTML of extensible record annotations

### DIFF
--- a/src/frontend/Docs/Entry.elm
+++ b/src/frontend/Docs/Entry.elm
@@ -237,7 +237,7 @@ aliasAnnotation nameDict name vars tipe =
                       )
 
                     Just extName ->
-                      ( [ [ text "    { ", text extName, text " |" ] ]
+                      ( [ [ text "    { ", text extName ] ]
                       , text "      | " :: List.repeat (List.length fields) (text "      , ")
                       )
             in


### PR DESCRIPTION
This fixes #161.

Records with just on field still occupy three lines. One could argue if those should only need one line, but that would be a different issue.