### PR TITLE
Fix header text incorrectly wrapping

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -59,11 +59,16 @@ pre {
 }
 
 .header {
+  display: flex;
   padding: 10px 0;
   color: #333333;
   font-size: 24px;
   margin: 0;
   text-overflow: ellipsis;
+}
+
+.header > a:first-of-type {
+  margin-right: 20px;
 }
 
 .header a:hover {


### PR DESCRIPTION
The header text at [package.elm-lang.org/](http://package.elm-lang.org/) is wrapping and making the header extra tall:

![elm-package-before](https://cloud.githubusercontent.com/assets/77758/15271753/e0436b04-1a15-11e6-8888-1d5c0114597d.png)

This PR just adds `display: flex` to `.header` and adds `margin-right: 20px` to the logo:

![elm-package-after](https://cloud.githubusercontent.com/assets/77758/15271752/e0435c22-1a15-11e6-91b3-107ffd85f319.png)

Tested in Chrome/Firefox on Xubuntu.