### PR TITLE
Fixes /help/docs-preview

### DIFF
--- a/src/backend/ServeFile.hs
+++ b/src/backend/ServeFile.hs
@@ -92,7 +92,9 @@ pkgPreview =
       \    };\n\
       \}\n\
       \\n\
-      \document.getElementById('fileLoader').addEventListener('change', handleFileSelect, false);\n"
+      \setTimeout(function() {\n\
+      \  document.getElementById('fileLoader').addEventListener('change', handleFileSelect, false);\n\
+      \}, 0)\n"
 
 
 


### PR DESCRIPTION
[/help/docs-preview](http://package.elm-lang.org/help/docs-preview) is currently broken due to a couple javascript errors. This PR fixes issue https://github.com/elm-lang/package.elm-lang.org/issues/170.

```
Uncaught TypeError: Cannot read property 'addEventListener' of null
```
```
Page-PreviewDocumentation.js?1463181367:2936 Uncaught Error: You trying to initialize module `Page.PreviewDocumentation` with an unexpected argument.
When trying to convert it to a usable Elm value, I run into this problem:

Expecting a String but instead got: {"uploads":""}
```