### PR TITLE
Add elm-community/linear-algebra to native whitelist. 

### DIFF
--- a/native-whitelist.json
+++ b/native-whitelist.json
@@ -3,6 +3,7 @@
     "elm-community/elm-history",
     "elm-community/elm-linear-algebra",
     "elm-community/elm-webgl",
+    "elm-community/linear-algebra",
     "elm-lang/animation-frame",
     "elm-lang/core",
     "elm-lang/dom",


### PR DESCRIPTION
This is a new name for elm-community/elm-linear-algebra which we will soon mark as "deprecated".

See https://github.com/elm-community/elm-linear-algebra/issues/12
