### PR TITLE
Whitelist elm-community/webgl

### DIFF
--- a/native-whitelist.json
+++ b/native-whitelist.json
@@ -3,6 +3,7 @@
     "elm-community/elm-linear-algebra",
     "elm-community/elm-webgl",
     "elm-community/linear-algebra",
+    "elm-community/webgl",
     "elm-lang/animation-frame",
     "elm-lang/core",
     "elm-lang/dom",


### PR DESCRIPTION
As previously discussed on Slack, this is a whitelist request for [elm-community/webgl](https://github.com/elm-community/webgl).

I ported the library to 0.18 and made sure that all the examples are working with the latest [linear-algebra](http://package.elm-lang.org/packages/elm-community/linear-algebra/latest).