### PR TITLE
Add libreirc/elm-crypto to native whitelist

### DIFF
--- a/native-whitelist.json
+++ b/native-whitelist.json
@@ -24,5 +24,6 @@
     "seliopou/elm-d3",
     "ThomasWeiser/elmfire",
     "Skinney/elm-array-exploration",
-    "BrianHicks/elm-benchmark"
+    "BrianHicks/elm-benchmark",
+    "libreirc/elm-crypto"
 ]


### PR DESCRIPTION
[elm-crypto](https://github.com/libreirc/elm-crypto) wraps Web Cryptography API with Elm's Task interfaces.

LibreIRC is a working group who are trying to make an IRC client using Elm. We found that it is necessary to wrap Web Cryptography API to retrieve cryptographically secure pseudorandom number in Elm. So we forked the blacktaxi/elm-random-secure and updated it to Elm 0.18.

Web Cryptography API is critical for performing cryptographic operations in web browsers. Please review the package and give us a feedback if there's something lacks. Thanks!

###### References
- https://github.com/libreirc/elm-crypto