### PR TITLE
constrain snap-core version < 1.0.0.0

### DIFF
--- a/run-server.cabal
+++ b/run-server.cabal
@@ -49,7 +49,7 @@ Executable run-server
     directory,
     filepath,
     mtl,
-    snap-core,
+    snap-core < 1.0.0.0,
     snap-server,
     text,
     time,


### PR DESCRIPTION
Necessary due to a change in snap-core-1.0.0.0 to function signature
for `Snap.Util.FileUploads.handleFileUploads` from
```
handleFileUploads
  :: MonadSnap m
  => FilePath
  -> UploadPolicy
  -> (PartInfo -> PartUploadPolicy)
  -> ([(PartInfo, Either PolicyViolationException FilePath)] -> m a)
  -> m a
```

to
```
handleFileUploads
  :: MonadSnap m
  => FilePath
  -> UploadPolicy
  -> (PartInfo -> PartUploadPolicy)
  -> ([(PartInfo, Either PolicyViolationException FilePath)] -> m a)
  -> m [a]
```

`cabal build` fails with snap-core >= 1.0.0.0 due to this function being used in `src/backend/Routes.hs`