### PR TITLE
add 600 font weight for Source Code Pro to import

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro);
+@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro:400,600);
 
 html, head, body {
   margin: 0;


### PR DESCRIPTION
Documentation text with styles "font-family : 'Source Code Pro'" and "font-weight: bold" renders poorly. Importing both the 400 and 600 weight styles from Google Fonts fixes this.