### PR TITLE
Document steps for running site backend locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ It is best practice to use [semantic versioning](http://semver.org/) when choosi
 
 ![automatic semantic versioning](https://github.com/elm-lang/elm-lang.org/blob/master/assets/home/semver.png?raw=true)
 
-
 ## Reliability
 
 All community packages are written entirely in Elm, so all the things that make your apps reliable are helping make packages reliable.
@@ -20,3 +19,57 @@ All community packages are written entirely in Elm, so all the things that make 
 A small set of packages provide access to [The Web Platform](https://platform.html5.org/). These packages are managed by @elm-lang to ensure that (1) the APIs are exposed in a way that makes sense for Elm and (2) they are carefully vetted to make sure the underlying JS code is stable. We cover a decent amount of The Web Platform now, but you can always use [ports][] if something is not covered yet!
 
 [ports]: https://guide.elm-lang.org/interop/javascript.html#ports
+
+## Developing and running package site locally
+
+1. Install [Elm][elm-installation] and [Haskell platform][haskell-platform]
+2. Clone Elm compiler repo for importing website dependencies:
+
+   ```
+   git clone git@github.com:elm/compiler
+   ```
+
+3. Create own directory for website projects and clone this repository there
+
+   ```
+   mkdir sites
+   cd sites
+   git clone git@github.com:elm/package.elm-lang.org
+   ```
+
+   Now you should have following directory layout:
+
+   ```
+   .
+   ├── compiler
+   └── sites
+       └── package.elm-lang.org
+   ```
+
+4. Install site dependencies and build project
+
+   ```
+   cd package.elm-lang.org
+   cabal install --only-dependencies
+   cabal build
+   ```
+
+5. Seed packages data from production site with included shell script
+
+   ```
+   sh seed.sh
+   ```
+
+6. [Generate access token for Github][github-token]
+
+7. Run server
+
+   ```
+   dist/build/run-server/run-server --port 8080 --github YOUR-TOKEN
+   ```
+
+   Now you are able to access locally running site at: http://localhost:8080 :tada:
+
+[elm-installation]: https://guide.elm-lang.org/install.html
+[haskell-platform]: https://www.haskell.org/platform/
+[github-token]: https://github.com/settings/tokens

--- a/seed.sh
+++ b/seed.sh
@@ -1,0 +1,29 @@
+#! /bin/sh
+#
+# Seed local development environment by downloading some of the core packages
+# from production instance.
+#
+# Dependencies for this script:
+# - curl
+# - jq
+
+SITE=https://package.elm-lang.org
+PACKAGES=(elm/core elm/html elm/json elm/browser elm/url elm/http)
+
+PACKAGE_FILES=(elm.json README.md docs.json endpoint.json time.dat)
+
+for p in ${PACKAGES[*]}; do
+  echo $p
+  mkdir -p packages/$p
+  pushd packages/$p
+  curl -O $SITE/packages/$p/releases.json
+  for v in $(jq -r 'keys[]' < releases.json); do
+    mkdir $v
+    pushd $v
+    for f in ${PACKAGE_FILES[*]}; do
+      curl -O $SITE/packages/$p/$v/$f
+    done
+    popd
+  done
+  popd
+done


### PR DESCRIPTION
I bootstrapped local dev environment through some trial and error to be able to study site implementation and possibly contribute more in the future.

I documented the necessary steps in `README.md` and made `seed.sh` shell script for bootstrapping local development environment packages data by downloading number of core packages from production site.

I'm hoping that this could help other possible contributors too to get started. I'm looking forward for the feedback in case I made something stupid here :sweat_smile: 