### PR TITLE
Show multiple warnings in documentation layout

### DIFF
--- a/src/frontend/Main.elm
+++ b/src/frontend/Main.elm
@@ -70,7 +70,7 @@ view model =
       Skeleton.view never
         { title = "Not Found"
         , header = []
-        , warning = Skeleton.NoProblems
+        , warnings = [Skeleton.NoProblems]
         , attrs = Problem.styles
         , kids = Problem.notFound
         }

--- a/src/frontend/Page/Diff.elm
+++ b/src/frontend/Page/Diff.elm
@@ -92,7 +92,7 @@ view model =
       [ Skeleton.authorSegment model.author
       , Skeleton.projectSegment model.author model.project
       ]
-  , warning = Skeleton.NoProblems
+  , warnings = [Skeleton.NoProblems]
   , attrs = [ class "pkg-overview" ]
   , kids =
       case model.releases of

--- a/src/frontend/Page/Docs.elm
+++ b/src/frontend/Page/Docs.elm
@@ -231,7 +231,7 @@ view : Model -> Skeleton.Details Msg
 view model =
   { title = toTitle model
   , header = toHeader model
-  , warning = toWarning model
+  , warnings = toWarnings model
   , attrs = []
   , kids =
       [ viewContent model
@@ -296,18 +296,18 @@ toHeader model =
 -- WARNING
 
 
-toWarning : Model -> Skeleton.Warning
-toWarning model =
+toWarnings : Model -> List Skeleton.Warning
+toWarnings model =
   case Dict.get (model.author ++ "/" ++ model.project) renames of
     Just (author, project) ->
-      Skeleton.WarnMoved author project
+      [Skeleton.WarnMoved author project]
 
     Nothing ->
       case model.outline of
-        Failure -> warnIfNewer model
-        Loading -> warnIfNewer model
+        Failure -> [warnIfNewer model]
+        Loading -> [warnIfNewer model]
         Success outline ->
-          if isOld outline.elm then Skeleton.WarnOld else warnIfNewer model
+          if isOld outline.elm then [Skeleton.WarnOld, warnIfNewer model] else [warnIfNewer model]
 
 
 warnIfNewer : Model -> Skeleton.Warning

--- a/src/frontend/Page/Help.elm
+++ b/src/frontend/Page/Help.elm
@@ -67,7 +67,7 @@ view : Model -> Skeleton.Details msg
 view model =
   { title = model.title
   , header = []
-  , warning = Skeleton.NoProblems
+  , warnings = [Skeleton.NoProblems]
   , attrs = []
   , kids = [ viewContent model.title model.content ]
   }

--- a/src/frontend/Page/Search.elm
+++ b/src/frontend/Page/Search.elm
@@ -96,7 +96,7 @@ view : Model -> Skeleton.Details Msg
 view model =
   { title = "Elm Packages"
   , header = []
-  , warning = Skeleton.NoProblems
+  , warnings = [Skeleton.NoProblems]
   , attrs = []
   , kids =
       [ lazy2 viewSearch model.query model.entries

--- a/src/frontend/Skeleton.elm
+++ b/src/frontend/Skeleton.elm
@@ -26,7 +26,7 @@ import Utils.Logo as Logo
 type alias Details msg =
   { title : String
   , header : List Segment
-  , warning : Warning
+  , warnings : List Warning
   , attrs : List (Attribute msg)
   , kids : List (Html msg)
   }
@@ -83,7 +83,7 @@ view toMsg details =
       details.title
   , body =
       [ viewHeader details.header
-      , lazy viewWarning details.warning
+      , lazy viewWarnings details.warnings
       , Html.map toMsg <|
           div (class "center" :: style "flex" "1" :: details.attrs) details.kids
       , viewFooter
@@ -126,35 +126,38 @@ viewSegment segment =
 
 -- VIEW WARNING
 
+viewWarnings : List Warning -> Html msg
+viewWarnings warnings =
+  div [ class "header-underbar" ] <|
+    List.map viewWarning warnings
 
 viewWarning : Warning -> Html msg
 viewWarning warning =
-  div [ class "header-underbar" ] <|
-    case warning of
-      NoProblems ->
-        []
+  case warning of
+    NoProblems ->
+      Html.text ""
 
-      WarnOld ->
-        [ p [ class "version-warning" ]
-            [ text "NOTE — this package is not compatible with Elm 0.19.1"
+    WarnOld ->
+      p [ class "version-warning" ]
+        [ text "NOTE — this package is not compatible with Elm 0.19.1"
+        ]
+      
+
+    WarnMoved author project ->
+      p [ class "version-warning" ]
+        [ text "NOTE — this package moved to "
+        , a [ href (Href.toVersion author project Nothing) ]
+            [ text (author ++ "/" ++ project)
             ]
         ]
+      
 
-      WarnMoved author project ->
-        [ p [ class "version-warning" ]
-            [ text "NOTE — this package moved to "
-            , a [ href (Href.toVersion author project Nothing) ]
-                [ text (author ++ "/" ++ project)
-                ]
-            ]
+    WarnNewerVersion url version ->
+      p [ class "version-warning" ]
+        [ text "NOTE — the latest version is "
+        , a [ href url ] [ text (V.toString version) ]
         ]
-
-      WarnNewerVersion url version ->
-        [ p [ class "version-warning" ]
-            [ text "NOTE — the latest version is "
-            , a [ href url ] [ text (V.toString version) ]
-            ]
-        ]
+      
 
 
 


### PR DESCRIPTION
### What
* Adjust site layout to allow showing multiple warnings

### Why
When viewing documentation for a package, the site will only show a single warning near the top of the page (in the "header-underbar") if any warning exists. Sometimes a package will have multiple warnings (old and incompatible), but only the incompatible warning will be shown. It may be still useful to see the other warnings because they have useful information (like links to newer versions).

### Screenshots

#### Before
<img width="1200" alt="Screen Shot 2020-03-04 at 1 26 27 PM" src="https://user-images.githubusercontent.com/2845768/75924445-d215e680-5e1b-11ea-8056-5e0c18c0e6e2.png">

#### After
<img width="1200" alt="Screen Shot 2020-03-04 at 1 26 37 PM" src="https://user-images.githubusercontent.com/2845768/75924451-d7733100-5e1b-11ea-9e88-cacdd0c317c2.png">
