### PR TITLE
Add links for types from dependencies

### DIFF
--- a/src/frontend/Page/Docs.elm
+++ b/src/frontend/Page/Docs.elm
@@ -50,6 +50,7 @@ type alias Model =
   , readme : Status String
   , docs : Status (List Docs.Module)
   , outline : Status Outline.PackageInfo
+  , deps : List Session.ResolvedDep
   }
 
 
@@ -79,13 +80,12 @@ init session author project version focus =
   case Session.getReleases session author project of
     Just releases ->
       getInfo (Release.getLatestVersion releases) <|
-        Model session author project version focus "" (Success releases) Loading Loading Loading
+        Model session author project version focus "" (Success releases) Loading Loading Loading []
 
     Nothing ->
-      ( Model session author project version focus "" Loading Loading Loading Loading
+      ( Model session author project version focus "" Loading Loading Loading Loading []
       , Http.send GotReleases (Session.fetchReleases author project)
       )
-
 
 getInfo : V.Version -> Model -> ( Model, Cmd Msg )
 getInfo latest model =
@@ -94,10 +94,11 @@ getInfo latest model =
     project = model.project
     version = Maybe.withDefault latest model.version
     maybeInfo =
-      Maybe.map3 (\a b c -> (a,b,c))
+      Maybe.map4 (\a b c d -> ((a,b),(c,d)))
         (Session.getReadme model.session author project version)
         (Session.getDocs model.session author project version)
         (Session.getOutline model.session author project version)
+        (Session.getResolvedDeps model.session author project version)
   in
   case maybeInfo of
     Nothing ->
@@ -109,14 +110,31 @@ getInfo latest model =
           ]
       )
 
-    Just (readme, docs, outline) ->
+    Just ((readme, docs), (outline, resolvedDeps)) ->
       ( { model
             | readme = Success readme
             , docs = Success docs
             , outline = Success outline
+            , deps = resolvedDeps
         }
-      , scrollIfNeeded model.focus
+      , Cmd.batch
+          [ scrollIfNeeded model.focus
+          , getDepsDocs model.session resolvedDeps
+          ]
       )
+
+
+getDepsDocs : Session.Data -> List Session.ResolvedDep -> Cmd Msg
+getDepsDocs session resolvedDeps =
+  resolvedDeps
+    |> List.filter (\resolvedDep ->
+      case Session.getDocs session resolvedDep.author resolvedDep.project resolvedDep.version of
+        Just _ -> False -- No need to fetch docs once again
+        Maybe.Nothing -> True)
+    |> List.map (\resolvedDep ->
+        Session.fetchDocs resolvedDep.author resolvedDep.project resolvedDep.version
+          |> Http.send (GotDepDocs resolvedDep))
+    |> Cmd.batch
 
 
 scrollIfNeeded : Focus -> Cmd Msg
@@ -143,6 +161,8 @@ type Msg
   | GotReadme V.Version (Result Http.Error String)
   | GotDocs V.Version (Result Http.Error (List Docs.Module))
   | GotOutline V.Version (Result Http.Error Outline.PackageInfo)
+  | GotResolvedDeps V.Version (List Session.ResolvedDep)
+  | GotDepDocs Session.ResolvedDep (Result Http.Error (List Docs.Module))
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -207,6 +227,21 @@ update msg model =
           , scrollIfNeeded model.focus
           )
 
+    GotDepDocs resolvedDep result ->
+      case result of
+        Ok docs ->
+          ( { model
+                | session = Session.addDocs resolvedDep.author resolvedDep.project resolvedDep.version docs model.session
+                }
+          , Cmd.none
+          )
+
+        _ ->
+          ( model
+          , Cmd.none
+          )
+
+
     GotOutline version result ->
       case result of
         Err _ ->
@@ -219,9 +254,16 @@ update msg model =
                 | outline = Success outline
                 , session = Session.addOutline model.author model.project version outline model.session
             }
-          , Cmd.none
+          , Task.perform (GotResolvedDeps version) (Session.fetchResolvedDeps outline)
           )
 
+    GotResolvedDeps version resolvedDeps ->
+          ( { model
+                | deps = resolvedDeps
+                , session = Session.addResolvedDeps model.author model.project version resolvedDeps model.session
+            }
+          , getDepsDocs model.session resolvedDeps
+          )
 
 
 -- VIEW
@@ -397,7 +439,13 @@ viewContent model =
       lazy2 viewAbout model.outline model.releases
 
     Module name tag ->
-      lazy5 viewModule model.author model.project model.version name model.docs
+      let depsDocs =
+            model.deps
+              |> List.filterMap (\resolvedDep ->
+                Session.getDocs model.session resolvedDep.author resolvedDep.project resolvedDep.version
+                  |> Maybe.map (Tuple.pair resolvedDep))
+      in
+      lazy6 viewModule model.author model.project model.version name model.docs depsDocs
 
 
 
@@ -423,15 +471,15 @@ viewReadme status =
 -- VIEW MODULE
 
 
-viewModule : String -> String -> Maybe V.Version -> String -> Status (List Docs.Module) -> Html msg
-viewModule author project version name status =
+viewModule : String -> String -> Maybe V.Version -> String -> Status (List Docs.Module) -> List (Session.ResolvedDep, List Docs.Module) -> Html msg
+viewModule author project version name status depsDocs =
   case status of
     Success allDocs ->
       case findModule name allDocs of
         Just docs ->
           let
             header = h1 [class "block-list-title"] [ text name ]
-            info = Block.makeInfo author project version name allDocs
+            info = Block.makeInfo author project version name allDocs depsDocs
             blocks = List.map (Block.view info) (Docs.toBlocks docs)
           in
           div [ class "block-list" ] (header :: blocks)

--- a/src/frontend/Page/Docs/Block.elm
+++ b/src/frontend/Page/Docs/Block.elm
@@ -12,6 +12,7 @@ import Elm.Version as V
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Href
+import Session
 import Utils.Markdown as Markdown
 
 
@@ -168,6 +169,20 @@ unionMore info =
 
 -- INFO
 
+type alias LinkInfo r =
+  { r
+  | author : String
+  , project : String
+  , version : Maybe V.Version
+  , moduleName : String
+  }
+
+
+type alias DepInfo =
+  { resolvedDep : Session.ResolvedDep
+  , typeNameDict : TypeNameDict
+  }
+
 
 type alias Info =
   { author : String
@@ -175,6 +190,7 @@ type alias Info =
   , version : Maybe V.Version
   , moduleName : String
   , typeNameDict : TypeNameDict
+  , depsInfo : List DepInfo
   }
 
 
@@ -182,8 +198,8 @@ type alias TypeNameDict =
   Dict.Dict String (String, String)
 
 
-makeInfo : String -> String -> Maybe V.Version -> String -> List Docs.Module -> Info
-makeInfo author project version moduleName docsList =
+typeNameDictFromDocs : List Docs.Module -> TypeNameDict
+typeNameDictFromDocs docsList =
   let
     addEntry home entry docs =
       Dict.insert (home ++ "." ++ entry.name) (home, entry.name) docs
@@ -193,9 +209,17 @@ makeInfo author project version moduleName docsList =
         |> \unions -> List.foldl (addEntry docs.name) unions docs.unions
         |> \aliases -> List.foldl (addEntry docs.name) aliases docs.aliases
   in
-    Info author project version moduleName <|
-      List.foldl addModule Dict.empty docsList
+  List.foldl addModule Dict.empty docsList
 
+
+makeInfo : String -> String -> Maybe V.Version -> String -> List Docs.Module -> List (Session.ResolvedDep, List Docs.Module) -> Info
+makeInfo author project version moduleName docsList depsDocs =
+  let depsInfo =
+        depsDocs
+          |> List.map (\(resolvedDep, depDocs) ->
+              DepInfo resolvedDep (typeNameDictFromDocs depDocs))
+  in
+  Info author project version moduleName (typeNameDictFromDocs docsList) depsInfo
 
 
 -- CREATE LINKS
@@ -211,7 +235,7 @@ bold =
   style "font-weight" "bold"
 
 
-makeLink : Info -> List (Attribute msg) -> String -> String -> Html msg
+makeLink : LinkInfo r -> List (Attribute msg) -> String -> String -> Html msg
 makeLink {author, project, version, moduleName} attrs tagName humanName =
   let
     url =
@@ -224,11 +248,34 @@ toLinkLine : Info -> String -> Lines (Line msg)
 toLinkLine info qualifiedName =
   case Dict.get qualifiedName info.typeNameDict of
     Nothing ->
-      let
-        shortName =
-          last qualifiedName (String.split "." qualifiedName)
+      let depRef =
+            info.depsInfo
+              |> List.filterMap (\i ->
+                  i.typeNameDict
+                    |> Dict.get qualifiedName
+                    |> Maybe.map (Tuple.pair i))
+              |> List.head
       in
-      One (String.length shortName) [ span [ title qualifiedName ] [ text shortName ] ]
+      case depRef of
+        Nothing ->
+          let
+            shortName =
+              last qualifiedName (String.split "." qualifiedName)
+          in
+          One (String.length shortName) [ span [ title qualifiedName ] [ text shortName ] ]
+
+        Just (depInfo, (moduleName, name)) ->
+          One (String.length name)
+            [ makeLink
+              { author = depInfo.resolvedDep.author
+              , project = depInfo.resolvedDep.project
+              , version = Just depInfo.resolvedDep.version
+              , moduleName = moduleName
+              }
+              []
+              name
+              name
+            ]
 
     Just (moduleName, name) ->
       One (String.length name) [ makeLink { info | moduleName = moduleName } [] name name ]

--- a/src/frontend/Page/Docs/Block.elm
+++ b/src/frontend/Page/Docs/Block.elm
@@ -185,11 +185,13 @@ type alias TypeNameDict =
 makeInfo : String -> String -> Maybe V.Version -> String -> List Docs.Module -> Info
 makeInfo author project version moduleName docsList =
   let
-    addUnion home union docs =
-      Dict.insert (home ++ "." ++ union.name) (home, union.name) docs
+    addEntry home entry docs =
+      Dict.insert (home ++ "." ++ entry.name) (home, entry.name) docs
 
     addModule docs dict =
-      List.foldl (addUnion docs.name) dict docs.unions
+      dict
+        |> \unions -> List.foldl (addEntry docs.name) unions docs.unions
+        |> \aliases -> List.foldl (addEntry docs.name) aliases docs.aliases
   in
     Info author project version moduleName <|
       List.foldl addModule Dict.empty docsList


### PR DESCRIPTION
The main thing this PR does is add links for types that are defined in dependencies.

The motivation is to be able to quickly navigate to related documentation that is directly relevant to a package's docs. It also helps to disambiguate what types a package uses, which is particularly useful for heavily overloaded type names such as `Color` (I can never figure out which one is intended :sweat_smile:).

In order to do this we have to find out which version of a dependency to link to. While it might be tempting to link to the latest version, it could lead to broken links if the type is removed/changed in the latest version of the dependency. As such we instead link to the most recent version that matches the constraint associated with the dependency. In this PR I am calling this a `ResolvedDep`.

This PR does 2 extra things:

- In the about section, link to the version from the `ResolvedDep` instead of `latest` if the dependency could be resolved.
- Link to type aliases and not just type unions. I now realise this was also done in https://github.com/elm/package.elm-lang.org/pull/353