### PR TITLE
Increase file size limit for docs.json

### DIFF
--- a/src/backend/Package/Register.hs
+++ b/src/backend/Package/Register.hs
@@ -235,7 +235,7 @@ handlePart pkg vsn dir info stream =
       boundedGzipAndWrite 128000 dir "elm.json" stream
 
     "docs.json" ->
-      boundedGzipAndWrite 768000 dir "docs.json" stream
+      boundedGzipAndWrite 1024000  dir "docs.json" stream
 
     "github-hash" ->
       boundedWriteEndpoint pkg vsn dir stream


### PR DESCRIPTION
The file size limit for docs.json is preventing the publishing of some packages, particularly those with generated content. This PR increases to limit to 1mb.

#361 